### PR TITLE
Also apply defaults when NewStreamingSubscriberWithStanConn is invoked

### DIFF
--- a/pkg/nats/subscriber.go
+++ b/pkg/nats/subscriber.go
@@ -129,7 +129,7 @@ func (c *StreamingSubscriberConfig) GetStreamingSubscriberSubscriptionConfig() S
 	}
 }
 
-func (c *StreamingSubscriberConfig) setDefaults() {
+func (c *StreamingSubscriberSubscriptionConfig) setDefaults() {
 	if c.SubscribersCount <= 0 {
 		c.SubscribersCount = 1
 	}
@@ -192,8 +192,6 @@ type StreamingSubscriber struct {
 //		}
 //		// ...
 func NewStreamingSubscriber(config StreamingSubscriberConfig, logger watermill.LoggerAdapter) (*StreamingSubscriber, error) {
-	config.setDefaults()
-
 	conn, err := stan.Connect(config.ClusterID, config.ClientID, config.StanOptions...)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot connect to NATS")
@@ -202,6 +200,8 @@ func NewStreamingSubscriber(config StreamingSubscriberConfig, logger watermill.L
 }
 
 func NewStreamingSubscriberWithStanConn(conn stan.Conn, config StreamingSubscriberSubscriptionConfig, logger watermill.LoggerAdapter) (*StreamingSubscriber, error) {
+	config.setDefaults()
+
 	if err := config.Validate(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Previously default values were applied on the `StreamingSubscriberConfig` object passed to `NewStreamingSubscriber`. If a client invokes `NewStreamingSubscriberWithStanConn` directly, the defaults were not applied.

Most importantly `SubscribersCount` and `CloseTimeout` were set there. If `SubscribersCount` is left at 0, nothing will happen. If `CloseTimeout` is left at 0, subscription might be closed after the connection has already been closed.

This PR fixes that by applying default values on the `StreamingSubscriberSubscriptionConfig` object passed to `NewStreamingSubscriberWithStanConn`. Since `NewStreamingSubscriber` invokes `NewStreamingSubscriberWithStanConn`, with a `StreamingSubscriberSubscriptionConfig` derived from the `StreamingSubscriberConfig` passed to it, the existing behaviour for `NewStreamingSubscriber` is kept.

Since no defaults were applied to the values used by `NewStreamingSubscriber`, the old `setDefault` function for `StreamingSubscriberConfig` has been removed. If defaults were ever to be applied, it would have to be added again.