### PR TITLE
fix: implement Delay interface for StaticDelay and MaxRetryDelay

### DIFF
--- a/pkg/nats/delay.go
+++ b/pkg/nats/delay.go
@@ -14,6 +14,8 @@ type Delay interface {
 	WaitTime(retryNum uint64) time.Duration
 }
 
+var _ Delay = (*StaticDelay)(nil)
+
 // StaticDelay delay that always return the same time.Duration
 type StaticDelay struct {
 	Delay time.Duration
@@ -23,24 +25,26 @@ func NewStaticDelay(delay time.Duration) StaticDelay {
 	return StaticDelay{Delay: delay}
 }
 
-func (s StaticDelay) WaitTime(retryNum int) time.Duration {
+func (s StaticDelay) WaitTime(retryNum uint64) time.Duration {
 	return s.Delay
 }
+
+var _ Delay = (*MaxRetryDelay)(nil)
 
 // MaxRetryDelay delay that returns the same time.Duration up to a maximum before sending term
 type MaxRetryDelay struct {
 	StaticDelay
-	maxRetries int
+	maxRetries uint64
 }
 
-func NewMaxRetryDelay(delay time.Duration, retryLimit int) MaxRetryDelay {
+func NewMaxRetryDelay(delay time.Duration, retryLimit uint64) MaxRetryDelay {
 	return MaxRetryDelay{
 		StaticDelay: NewStaticDelay(delay),
 		maxRetries:  retryLimit,
 	}
 }
 
-func (s MaxRetryDelay) WaitTime(retryNum int) time.Duration {
+func (s MaxRetryDelay) WaitTime(retryNum uint64) time.Duration {
 	if retryNum >= s.maxRetries {
 		return TermSignal
 	}

--- a/pkg/nats/delay_test.go
+++ b/pkg/nats/delay_test.go
@@ -20,7 +20,7 @@ func TestStaticDelay(t *testing.T) {
 
 func TestMaxRetryDelay(t *testing.T) {
 	delay := time.Minute
-	maxRetry := 5
+	maxRetry := uint64(5)
 
 	sd := nats.NewMaxRetryDelay(delay, maxRetry)
 


### PR DESCRIPTION
`Delay` interface for the `waitTime` param currently uses `uint64` type, whereas the `StaticDelay` and `MaxRetryDelay` strategies use `int` type. Consequently, none of these built-in delay strategies can be used.

There are two options to fix this issue:

1. We can fix type in the interface, but this would break user-defined implementations of the interface. Btw in NATS metadata (`metadata.NumDelivered`) this param has `uint64` type.
2. We can fix types in the built-in `StaticDelay` and `MaxRetryDelay` delay strategies. However, this change would break these strategies for anyone who uses them outside of the `watermill-nats` library.

I've chosen the second option as it is expected to cause less damage. I don't think that anyone is using these structs outside of `watermill-nats`. The first option is more dangerous because some users may have already created their own implementations (like me, i created an `ExponentialDelay` for my project).