### PR TITLE
add pullConsumeOptions

### DIFF
--- a/pkg/jetstream/config.go
+++ b/pkg/jetstream/config.go
@@ -53,8 +53,8 @@ type SubscriberConfig struct {
 	// ConfigureConsumer is a custom function that can be used to define consumer configuration from a topic.  Publisher uses it to calculate publish destination from topic.
 	ConfigureConsumer ConsumerConfigurator
 
-	// PullConsumeOption is the option that adjusts pull consume behavior
-	PullConsumeOptions []natsJS.PullConsumeOpt
+	// ConsumeOptions is the option that adjusts consume behavior
+	ConsumeOptions []natsJS.PullConsumeOpt
 }
 
 // setDefaults sets default values needed for a subscriber if unset

--- a/pkg/jetstream/config.go
+++ b/pkg/jetstream/config.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ThreeDotsLabs/watermill"
 	"github.com/nats-io/nats.go"
+	natsJS "github.com/nats-io/nats.go/jetstream"
 )
 
 // PublisherConfig defines the watermill configuration for a JetStream publisher
@@ -51,6 +52,9 @@ type SubscriberConfig struct {
 	ConfigureStream StreamConfigurator
 	// ConfigureConsumer is a custom function that can be used to define consumer configuration from a topic.  Publisher uses it to calculate publish destination from topic.
 	ConfigureConsumer ConsumerConfigurator
+
+	// PullConsumeOption is the option that adjusts pull consume behavior
+	PullConsumeOptions []natsJS.PullConsumeOpt
 }
 
 // setDefaults sets default values needed for a subscriber if unset

--- a/pkg/jetstream/consumer.go
+++ b/pkg/jetstream/consumer.go
@@ -120,6 +120,7 @@ func createOrUpdateConsumerWithCloser(ctx context.Context,
 func consume(ctx context.Context,
 	closing chan struct{},
 	consumer jetstream.Consumer,
+	pullConsumeOpts []jetstream.PullConsumeOpt,
 	cb handleFunc,
 	deferred func(),
 ) (chan *message.Message, error) {
@@ -129,7 +130,7 @@ func consume(ctx context.Context,
 	// add support for batching pull consumers using consumer.Fetch / FetchNoWait
 	cc, err := consumer.Consume(func(msg jetstream.Msg) {
 		cb(ctx, msg, output)
-	})
+	}, pullConsumeOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start jetstream consumer: %w", err)
 	}

--- a/pkg/jetstream/subscriber.go
+++ b/pkg/jetstream/subscriber.go
@@ -19,20 +19,20 @@ var _ message.Subscriber = &Subscriber{}
 
 // Subscriber provides a watermill subscriber interface to NATS JetStream
 type Subscriber struct {
-	nc                 *nats.Conn
-	js                 jetstream.JetStream
-	logger             watermill.LoggerAdapter
-	closed             bool
-	closing            chan struct{}
-	ackWait            time.Duration
-	outputsWg          *sync.WaitGroup
-	closeTimeout       time.Duration
-	subsLock           *sync.RWMutex
-	consumerBuilder    ResourceInitializer
-	nakDelay           Delay
-	configureStream    StreamConfigurator
-	configureConsumer  ConsumerConfigurator
-	pullConsumeOptions []jetstream.PullConsumeOpt
+	nc                *nats.Conn
+	js                jetstream.JetStream
+	logger            watermill.LoggerAdapter
+	closed            bool
+	closing           chan struct{}
+	ackWait           time.Duration
+	outputsWg         *sync.WaitGroup
+	closeTimeout      time.Duration
+	subsLock          *sync.RWMutex
+	consumerBuilder   ResourceInitializer
+	nakDelay          Delay
+	configureStream   StreamConfigurator
+	configureConsumer ConsumerConfigurator
+	consumeOptions    []jetstream.PullConsumeOpt
 }
 
 // NewSubscriber creates a new watermill JetStream subscriber.
@@ -60,18 +60,18 @@ func newSubscriber(nc *nats.Conn, config *SubscriberConfig) (*Subscriber, error)
 		return nil, fmt.Errorf("initializing jetstream: %w", err)
 	}
 	return &Subscriber{
-		nc:                 nc,
-		js:                 js,
-		closing:            make(chan struct{}),
-		logger:             config.Logger,
-		ackWait:            config.AckWaitTimeout,
-		outputsWg:          &sync.WaitGroup{},
-		closeTimeout:       5 * time.Second,
-		subsLock:           &sync.RWMutex{},
-		consumerBuilder:    config.ResourceInitializer,
-		configureStream:    config.ConfigureStream,
-		configureConsumer:  config.ConfigureConsumer,
-		pullConsumeOptions: config.PullConsumeOptions,
+		nc:                nc,
+		js:                js,
+		closing:           make(chan struct{}),
+		logger:            config.Logger,
+		ackWait:           config.AckWaitTimeout,
+		outputsWg:         &sync.WaitGroup{},
+		closeTimeout:      5 * time.Second,
+		subsLock:          &sync.RWMutex{},
+		consumerBuilder:   config.ResourceInitializer,
+		configureStream:   config.ConfigureStream,
+		configureConsumer: config.ConfigureConsumer,
+		consumeOptions:    config.ConsumeOptions,
 	}, nil
 }
 
@@ -104,7 +104,7 @@ func (s *Subscriber) Subscribe(ctx context.Context, topic string) (<-chan *messa
 
 	s.outputsWg.Add(1)
 
-	return consume(ctx, s.closing, consumer, s.pullConsumeOptions, s.handleMsg, cleanup)
+	return consume(ctx, s.closing, consumer, s.consumeOptions, s.handleMsg, cleanup)
 }
 
 // Close closes the subscriber and signals to close any subscriptions it created along with the underlying connection.

--- a/pkg/jetstream/subscriber.go
+++ b/pkg/jetstream/subscriber.go
@@ -19,19 +19,20 @@ var _ message.Subscriber = &Subscriber{}
 
 // Subscriber provides a watermill subscriber interface to NATS JetStream
 type Subscriber struct {
-	nc                *nats.Conn
-	js                jetstream.JetStream
-	logger            watermill.LoggerAdapter
-	closed            bool
-	closing           chan struct{}
-	ackWait           time.Duration
-	outputsWg         *sync.WaitGroup
-	closeTimeout      time.Duration
-	subsLock          *sync.RWMutex
-	consumerBuilder   ResourceInitializer
-	nakDelay          Delay
-	configureStream   StreamConfigurator
-	configureConsumer ConsumerConfigurator
+	nc                 *nats.Conn
+	js                 jetstream.JetStream
+	logger             watermill.LoggerAdapter
+	closed             bool
+	closing            chan struct{}
+	ackWait            time.Duration
+	outputsWg          *sync.WaitGroup
+	closeTimeout       time.Duration
+	subsLock           *sync.RWMutex
+	consumerBuilder    ResourceInitializer
+	nakDelay           Delay
+	configureStream    StreamConfigurator
+	configureConsumer  ConsumerConfigurator
+	pullConsumeOptions []jetstream.PullConsumeOpt
 }
 
 // NewSubscriber creates a new watermill JetStream subscriber.
@@ -59,17 +60,18 @@ func newSubscriber(nc *nats.Conn, config *SubscriberConfig) (*Subscriber, error)
 		return nil, fmt.Errorf("initializing jetstream: %w", err)
 	}
 	return &Subscriber{
-		nc:                nc,
-		js:                js,
-		closing:           make(chan struct{}),
-		logger:            config.Logger,
-		ackWait:           config.AckWaitTimeout,
-		outputsWg:         &sync.WaitGroup{},
-		closeTimeout:      5 * time.Second,
-		subsLock:          &sync.RWMutex{},
-		consumerBuilder:   config.ResourceInitializer,
-		configureStream:   config.ConfigureStream,
-		configureConsumer: config.ConfigureConsumer,
+		nc:                 nc,
+		js:                 js,
+		closing:            make(chan struct{}),
+		logger:             config.Logger,
+		ackWait:            config.AckWaitTimeout,
+		outputsWg:          &sync.WaitGroup{},
+		closeTimeout:       5 * time.Second,
+		subsLock:           &sync.RWMutex{},
+		consumerBuilder:    config.ResourceInitializer,
+		configureStream:    config.ConfigureStream,
+		configureConsumer:  config.ConfigureConsumer,
+		pullConsumeOptions: config.PullConsumeOptions,
 	}, nil
 }
 
@@ -102,7 +104,7 @@ func (s *Subscriber) Subscribe(ctx context.Context, topic string) (<-chan *messa
 
 	s.outputsWg.Add(1)
 
-	return consume(ctx, s.closing, consumer, s.handleMsg, cleanup)
+	return consume(ctx, s.closing, consumer, s.pullConsumeOptions, s.handleMsg, cleanup)
 }
 
 // Close closes the subscriber and signals to close any subscriptions it created along with the underlying connection.


### PR DESCRIPTION
Allow passing PullConsumeOpt to the NATS JetStream subscriber when using the new API so that we could adjust the default behavior of `Consume()`.

Unit tests passed:

<img width="1064" alt="image" src="https://github.com/ThreeDotsLabs/watermill-nats/assets/50090692/9827f833-ac5c-4d9a-aef4-6e05f15416e7">
