### PR TITLE
Add nak delay from config to Jetstream subscriber

### DIFF
--- a/pkg/jetstream/subscriber.go
+++ b/pkg/jetstream/subscriber.go
@@ -74,6 +74,7 @@ func newSubscriber(nc *nats.Conn, config *SubscriberConfig) (*Subscriber, error)
 		configureConsumer: config.ConfigureConsumer,
 		consumeOptions:    config.ConsumeOptions,
 		ackAsync:          config.AckAsync,
+		nakDelay:          config.NakDelay,
 	}, nil
 }
 


### PR DESCRIPTION
It turned out that the nak delay option is never applied to Jetstream subscribers. This should be the fix for it.