### PR TITLE
Allow library users to override the mapping from NATS message to Watermill one

### DIFF
--- a/pkg/jetstream/config.go
+++ b/pkg/jetstream/config.go
@@ -58,6 +58,8 @@ type SubscriberConfig struct {
 
 	// AckAsync enables asynchronous acknowledgement
 	AckAsync bool
+
+	Unmarshaler Unmarshaler
 }
 
 // setDefaults sets default values needed for a subscriber if unset
@@ -80,5 +82,9 @@ func (s *SubscriberConfig) setDefaults() {
 
 	if s.ConfigureConsumer == nil {
 		s.ConfigureConsumer = defaultConsumerConfigurator
+	}
+
+	if s.Unmarshaler == nil {
+		s.Unmarshaler = DefaultUnmarshaler{}
 	}
 }

--- a/pkg/jetstream/message_handler.go
+++ b/pkg/jetstream/message_handler.go
@@ -13,7 +13,7 @@ type handleFunc = func(ctx context.Context, msg jetstream.Msg, output chan *mess
 
 // handleMsg provides the core processing logic for a single JetStream message
 func (s *Subscriber) handleMsg(ctx context.Context, msg jetstream.Msg, output chan *message.Message) {
-	m, err := unmarshal(msg)
+	m, err := s.unmarshaler.Unmarshal(msg)
 	if err != nil {
 		s.logger.Error("cannot unmarshal message", err, nil)
 	}

--- a/pkg/jetstream/subscriber.go
+++ b/pkg/jetstream/subscriber.go
@@ -7,12 +7,10 @@ import (
 	"time"
 
 	"github.com/ThreeDotsLabs/watermill"
-	wmnats "github.com/ThreeDotsLabs/watermill-nats/v2/pkg/nats"
 	"github.com/ThreeDotsLabs/watermill/message"
 	watermillSync "github.com/ThreeDotsLabs/watermill/pubsub/sync"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
-	"github.com/pkg/errors"
 )
 
 var _ message.Subscriber = &Subscriber{}
@@ -34,6 +32,7 @@ type Subscriber struct {
 	configureConsumer ConsumerConfigurator
 	consumeOptions    []jetstream.PullConsumeOpt
 	ackAsync          bool
+	unmarshaler       Unmarshaler
 }
 
 // NewSubscriber creates a new watermill JetStream subscriber.
@@ -46,7 +45,6 @@ func NewSubscriber(config SubscriberConfig) (*Subscriber, error) {
 	if nc == nil {
 		var err error
 		nc, err = nats.Connect(config.URL)
-
 		if err != nil {
 			return nil, fmt.Errorf("failed to connect: %w", err)
 		}
@@ -75,6 +73,7 @@ func newSubscriber(nc *nats.Conn, config *SubscriberConfig) (*Subscriber, error)
 		consumeOptions:    config.ConsumeOptions,
 		ackAsync:          config.AckAsync,
 		nakDelay:          config.NakDelay,
+		unmarshaler:       config.Unmarshaler,
 	}, nil
 }
 
@@ -132,34 +131,4 @@ func (s *Subscriber) Close() error {
 	}
 
 	return nil
-}
-
-// unmarshal turns a given JetStream message into a watermill message.
-// Reserved NATS headers are not propagated in the resulting message Metadata.
-func unmarshal(msg jetstream.Msg) (*message.Message, error) {
-	data := msg.Data()
-
-	hdr := msg.Headers()
-
-	id := hdr.Get(wmnats.WatermillUUIDHdr)
-
-	md := make(message.Metadata)
-
-	for k, v := range hdr {
-		switch k {
-		case wmnats.WatermillUUIDHdr, nats.MsgIdHdr, nats.ExpectedLastMsgIdHdr, nats.ExpectedStreamHdr, nats.ExpectedLastSubjSeqHdr, nats.ExpectedLastSeqHdr:
-			continue
-		default:
-			if len(v) == 1 {
-				md.Set(k, v[0])
-			} else {
-				return nil, errors.Errorf("multiple values received in NATS header for %q: (%+v)", k, v)
-			}
-		}
-	}
-
-	wm := message.NewMessage(id, data)
-	wm.Metadata = md
-
-	return wm, nil
 }

--- a/pkg/jetstream/unmarshaler.go
+++ b/pkg/jetstream/unmarshaler.go
@@ -1,0 +1,45 @@
+package jetstream
+
+import (
+	wmnats "github.com/ThreeDotsLabs/watermill-nats/v2/pkg/nats"
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/pkg/errors"
+)
+
+type Unmarshaler interface {
+	Unmarshal(jetstream.Msg) (*message.Message, error)
+}
+
+type DefaultUnmarshaler struct{}
+
+// Unmarshal turns a given JetStream message into a watermill message.
+// Reserved NATS headers are not propagated in the resulting message Metadata.
+func (DefaultUnmarshaler) Unmarshal(msg jetstream.Msg) (*message.Message, error) {
+	data := msg.Data()
+
+	hdr := msg.Headers()
+
+	id := hdr.Get(wmnats.WatermillUUIDHdr)
+
+	md := make(message.Metadata)
+
+	for k, v := range hdr {
+		switch k {
+		case wmnats.WatermillUUIDHdr, nats.MsgIdHdr, nats.ExpectedLastMsgIdHdr, nats.ExpectedStreamHdr, nats.ExpectedLastSubjSeqHdr, nats.ExpectedLastSeqHdr:
+			continue
+		default:
+			if len(v) == 1 {
+				md.Set(k, v[0])
+			} else {
+				return nil, errors.Errorf("multiple values received in NATS header for %q: (%+v)", k, v)
+			}
+		}
+	}
+
+	wm := message.NewMessage(id, data)
+	wm.Metadata = md
+
+	return wm, nil
+}


### PR DESCRIPTION
I found myself in a need to have access to `Metadata` from NATS Jetstream. 
Specifically, I needed to know the number of `NumPending` so that I can mark a service as `ready` in `k8s` as soon as that number is close to 0. As well as `NumDelivered` to keep track of retries.

It looks to be the easiest to just go ahead and set that information on message headers. But for that, the `unmarshal` function you have should be configurable.

That allows me to do something like:
```go
type SomeUnmarshaler struct {
	jetstream.DefaultUnmarshaler
}

func (su SomeUnmarshaler) Unmarshal(msg natsJS.Msg) (*message.Message, error) {
	m, err := su.DefaultUnmarshaler.Unmarshal(msg)
	if err != nil {
		return m, err
	}

	meta, err := msg.Metadata()
	if err != nil {
		return m, nil //nolint:nilerr
	}

	m.Metadata.Set("messages-pending", strconv.FormatUint(meta.NumPending, 10))

	return m, nil
}
```