### PR TITLE
 jetstream: add TrackMsgId support in publisher

### DIFF
--- a/pkg/jetstream/config.go
+++ b/pkg/jetstream/config.go
@@ -20,6 +20,9 @@ type PublisherConfig struct {
 	Logger watermill.LoggerAdapter
 	// ConfigureStream is a custom function that can be used to define stream configuration from a topic.  Publisher uses it to calculate publish destination from topic.
 	ConfigureStream StreamConfigurator
+
+	// TrackMsgId sets Nats-Msg-Id to the msg UUID to prevent duplication (needed for exactly once processing).
+	TrackMsgId bool
 }
 
 // setDefaults sets default values needed for a publisher if unset

--- a/pkg/jetstream/config.go
+++ b/pkg/jetstream/config.go
@@ -21,8 +21,8 @@ type PublisherConfig struct {
 	// ConfigureStream is a custom function that can be used to define stream configuration from a topic.  Publisher uses it to calculate publish destination from topic.
 	ConfigureStream StreamConfigurator
 
-	// TrackMsgId sets Nats-Msg-Id to the msg UUID to prevent duplication (needed for exactly once processing).
-	TrackMsgId bool
+	// TrackMessageID sets Nats-Msg-Id to the msg UUID to prevent duplication (needed for exactly once processing).
+	TrackMessageID bool
 }
 
 // setDefaults sets default values needed for a publisher if unset

--- a/pkg/jetstream/publisher.go
+++ b/pkg/jetstream/publisher.go
@@ -20,6 +20,7 @@ type Publisher struct {
 	m               wmnats.Marshaler
 	logger          watermill.LoggerAdapter
 	configureStream StreamConfigurator
+	trackMsgId      bool
 }
 
 // NewPublisher creates a new watermill JetStream publisher.
@@ -53,6 +54,7 @@ func newPublisher(nc *nats.Conn, config *PublisherConfig) (*Publisher, error) {
 		m:               &wmnats.NATSMarshaler{},
 		logger:          config.Logger,
 		configureStream: config.ConfigureStream,
+		trackMsgId:      config.TrackMsgId,
 	}, nil
 }
 
@@ -64,6 +66,13 @@ func (p *Publisher) Publish(topic string, messages ...*message.Message) error {
 		nm, err := p.m.Marshal(streamConfig.Name, m)
 		if err != nil {
 			return fmt.Errorf("failed to marshal: %w", err)
+		}
+
+		if p.trackMsgId && m.UUID != "" {
+			if nm.Header == nil {
+				nm.Header = make(nats.Header)
+			}
+			nm.Header.Set(nats.MsgIdHdr, m.UUID)
 		}
 
 		_, err = p.js.PublishMsg(context.Background(), nm) //marshal

--- a/pkg/jetstream/publisher_test.go
+++ b/pkg/jetstream/publisher_test.go
@@ -1,0 +1,100 @@
+package jetstream_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ThreeDotsLabs/watermill"
+	"github.com/ThreeDotsLabs/watermill-nats/v2/pkg/jetstream"
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/nats-io/nats.go"
+	natsJS "github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublisher_TrackMsgId_SetsNatsMsgIdHeader(t *testing.T) {
+	ctx := context.Background()
+
+	topic := "watermill_test_" + watermill.NewShortUUID()
+
+	ncMgmt, err := nats.Connect(nats.DefaultURL)
+	require.NoError(t, err)
+	defer ncMgmt.Close()
+
+	js, err := natsJS.New(ncMgmt)
+	require.NoError(t, err)
+
+	_, err = js.CreateStream(ctx, natsJS.StreamConfig{
+		Name:     topic,
+		Subjects: []string{topic},
+	})
+	require.NoError(t, err)
+	defer func() { _ = js.DeleteStream(ctx, topic) }()
+
+	ncSub, err := nats.Connect(nats.DefaultURL)
+	require.NoError(t, err)
+	defer ncSub.Close()
+
+	sub, err := ncSub.SubscribeSync(topic)
+	require.NoError(t, err)
+	require.NoError(t, ncSub.Flush())
+
+	pub, err := jetstream.NewPublisher(jetstream.PublisherConfig{
+		URL:        nats.DefaultURL,
+		TrackMsgId: true,
+	})
+	require.NoError(t, err)
+	defer func() { _ = pub.Close() }()
+
+	wmMsg := message.NewMessage(watermill.NewUUID(), []byte("test"))
+	require.NoError(t, pub.Publish(topic, wmMsg))
+
+	natsMsg, err := sub.NextMsg(5 * time.Second)
+	require.NoError(t, err)
+
+	assert.Equal(t, wmMsg.UUID, natsMsg.Header.Get(nats.MsgIdHdr))
+}
+
+func TestPublisher_TrackMsgId_Disabled_DoesNotSetNatsMsgIdHeader(t *testing.T) {
+	ctx := context.Background()
+
+	topic := "watermill_test_" + watermill.NewShortUUID()
+
+	ncMgmt, err := nats.Connect(nats.DefaultURL)
+	require.NoError(t, err)
+	defer ncMgmt.Close()
+
+	js, err := natsJS.New(ncMgmt)
+	require.NoError(t, err)
+
+	_, err = js.CreateStream(ctx, natsJS.StreamConfig{
+		Name:     topic,
+		Subjects: []string{topic},
+	})
+	require.NoError(t, err)
+	defer func() { _ = js.DeleteStream(ctx, topic) }()
+
+	ncSub, err := nats.Connect(nats.DefaultURL)
+	require.NoError(t, err)
+	defer ncSub.Close()
+
+	sub, err := ncSub.SubscribeSync(topic)
+	require.NoError(t, err)
+	require.NoError(t, ncSub.Flush())
+
+	pub, err := jetstream.NewPublisher(jetstream.PublisherConfig{
+		URL: nats.DefaultURL,
+	})
+	require.NoError(t, err)
+	defer func() { _ = pub.Close() }()
+
+	wmMsg := message.NewMessage(watermill.NewUUID(), []byte("test"))
+	require.NoError(t, pub.Publish(topic, wmMsg))
+
+	natsMsg, err := sub.NextMsg(5 * time.Second)
+	require.NoError(t, err)
+
+	assert.Empty(t, natsMsg.Header.Get(nats.MsgIdHdr))
+}


### PR DESCRIPTION
### Motivation / Background

  JetStream deduplication relies on `Nats-Msg-Id`. `pkg/nats` already supports this via `JetStreamConfig.TrackMsgId`,
  but `pkg/jetstream` publisher required users to set the header manually through message metadata.
  This PR adds a first-class option to do it automatically.

  ### Details

  - Add `PublisherConfig.TrackMsgId`.
  - When enabled, set `nats.MsgIdHdr` (`Nats-Msg-Id`) to `message.UUID` before publishing (overwrites any existing value).
  - Add tests verifying the header is set/not set.

  ### Alternative approaches considered (if applicable)

  - Require users to always set `msg.Metadata.Set("Nats-Msg-Id", ...)` manually (easy to miss).
  - Expose generic JetStream publish options on the publisher API (larger surface for a single common need).

  ### Checklist

  - [x] I wrote tests for the changes.
  - [x] All tests are passing (`make up` + `make jetstream_test`).
  - [ ] Code has no breaking changes (adds a field to an exported struct; users of unkeyed composite literals may need to update).