### PR TITLE
use subjects for generating topic name instead of name from streamconfig

### DIFF
--- a/pkg/jetstream/publisher.go
+++ b/pkg/jetstream/publisher.go
@@ -61,7 +61,7 @@ func (p *Publisher) Publish(topic string, messages ...*message.Message) error {
 	streamConfig := p.configureStream(topic)
 	for _, m := range messages {
 		// TODO: how can we handle eg routing metadata without fallback to *nats.Msg
-		nm, err := p.m.Marshal(streamConfig.Name, m)
+		nm, err := p.m.Marshal(streamConfig.Subjects[0], m)
 		if err != nil {
 			return fmt.Errorf("failed to marshal: %w", err)
 		}


### PR DESCRIPTION
### Motivation / Background

The JetStream Publish function uses streamConfig.Name for the topic when marshaling the message, when it should be using streamConfig.Subjects. This is not a problem when using defaultStreamConfigurator since that sets the passed in topic as the name while also setting the first Subjects item to the topic. However, when using a custom (existing) stream config it is likely that the name will be different from the topic. This is because topics typically contain periods to reflect a topic hierarchy and periods cannot be used in stream names. Thus, a custom jetstream.StreamConfig likely appears similar to the following:

```
jetstream.StreamConfig{
    Name: "COMMAND_TEST",
    Subjects: []string{"command.test"},
    Storage: jetstream.FileStorage,
    Retention: 72 * time.Hour,
}
```

Typically, stream names are capitalized but that is not required.

### Details

This was a simple change to use streamConfig.Subjects[0] instead of streamConfig.Name for the topic when calling the Marshal function. This does not change the default behavior when the ConfigureStream PublisherConfig option is not used when creating a JetStream publisher since defaultStreamConfigurator sets both Name and Subjects with the passed-in topic.

### Checklist

The resources of our team are limited. **There are a couple of things that you can do to help us merge your PR faster**:

- [ ] I wrote tests for the changes.
- [x] All tests are passing.
  - If you are testing a Pub/Sub, you can start Docker with `make up`.
  - You can start with `make test_short` for a quick check.
  - If you want to run all tests, use `make test`.
- [x] Code has no breaking changes.
- [ ] _(If applicable)_ documentation on [watermill.io](https://watermill.io/) is updated.
  - Documentation is built in the [github.com/ThreeDotsLabs/watermill/docs](https://github.com/ThreeDotsLabs/watermill/tree/master/docs).
  - You can find development instructions in the [DEVELOP.md](https://github.com/ThreeDotsLabs/watermill/tree/master/docs/DEVELOP.md).
