### PR TITLE
Fix: JetStream ackWait timer starts before handler due to pre-buffering (#609)

### DIFF
--- a/pkg/jetstream/consumer.go
+++ b/pkg/jetstream/consumer.go
@@ -126,11 +126,16 @@ func consume(ctx context.Context,
 ) (chan *message.Message, error) {
 	output := make(chan *message.Message)
 
-	// TODO: this is the closest analog to callback based subscriptions in watermill-nats/pkg/nats
-	// add support for batching pull consumers using consumer.Fetch / FetchNoWait
+	// Use Fetch with PullMaxMessages=1 to avoid pre-buffering.
+	// consumer.Consume() pre-fetches messages internally, causing the NATS ackWait
+	// clock to start ticking before the handler sees the message. Over time,
+	// a backlog causes NATS to redeliver messages that were still being processed.
+	fetchOpts := append([]jetstream.PullConsumeOpt{}, pullConsumeOpts...)
+	fetchOpts = append(fetchOpts, jetstream.PullMaxMessages(1))
+
 	cc, err := consumer.Consume(func(msg jetstream.Msg) {
 		cb(ctx, msg, output)
-	}, pullConsumeOpts...)
+	}, fetchOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start jetstream consumer: %w", err)
 	}


### PR DESCRIPTION
### Summary

Fixes a timing bug in `consumer.Consume()` where NATS JetStream internal pre-buffering causes the ackWait clock to start ticking before the handler callback fires.

### Root Cause

`consumer.Consume()` pre-fetches messages into an internal buffer. NATS JetStream starts the ackWait clock when messages are delivered to the consumer, but watermill only starts its ackWait timer when `handleMsg` is called. With slow handlers or large backlogs, the real elapsed time far exceeds `AckWaitTimeout`, causing NATS to redeliver messages that are still being processed — resulting in duplicate processing.

### Fix

Added `jetstream.PullMaxMessages(1)` to consume options. This limits NATS to deliver one message at a time, keeping the ackWait clock aligned with actual handler execution time.

### Before/After

**Before:** `consumer.Consume(cb)` — pre-fetches N messages, ackWait for each starts when pulled by NATS
**After:** `consumer.Consume(cb, PullMaxMessages(1))` — delivers one at a time, ackWait aligns with handler

Fixes #609